### PR TITLE
修复默认生成View文件内无法正常使用events对象问题

### DIFF
--- a/generators/app/templates/app/scripts/views/doctor.js.ejs
+++ b/generators/app/templates/app/scripts/views/doctor.js.ejs
@@ -22,7 +22,7 @@
         },
         render: function () {
             this.$el.html(this.template({doctors:this.collection.toJSON()}));
-            $('#body').html(this.$el.html());
+            $('#body').html(this.$el.html);
             this.trigger("render", "render done!");
             return this;
         }

--- a/generators/app/templates/app/scripts/views/doctor_require.js.ejs
+++ b/generators/app/templates/app/scripts/views/doctor_require.js.ejs
@@ -27,7 +27,7 @@ define([
         },
         render: function () {
             this.$el.html(this.template({doctors:this.collection.toJSON()}));
-            $('#body').html(this.$el.html());
+            $('#body').html(this.$el.html);
             this.trigger("render", "render done!");
             return this;
         },

--- a/generators/templates/requirejs/view.js.ejs
+++ b/generators/templates/requirejs/view.js.ejs
@@ -25,7 +25,7 @@ define([
         },
         render: function () {
             this.$el.html(this.template({<%=collectionName.toString().toLowerCase() %>:this.collection.toJSON()}));
-            $('#body').html(this.$el.html());
+            $('#body').html(this.$el);
             this.trigger("render", "render done!");
             return this;
         },

--- a/generators/templates/view.js.ejs
+++ b/generators/templates/view.js.ejs
@@ -21,7 +21,7 @@
         },
         render: function () {
             this.$el.html(this.template({<%=collectionName.toString().toLowerCase() %>:this.collection.toJSON()}));
-            $('#body').html(this.$el.html());
+            $('#body').html(this.$el.html);
             this.trigger("render", "render done!");
             return this;
         },

--- a/readme.md
+++ b/readme.md
@@ -150,7 +150,7 @@ karma.conf.js: karma test config.
 ```
 ## Contribute
 
-When submitting a bugfix, write a test that exposes the bug and fails before applying your fix. Submit the test alongside the fix.
+When submitting a bugfix, write a *test* that exposes the bug and fails before applying your fix. Submit the test alongside the fix.
 
 When submitting a new feature, add tests that cover the feature.
 


### PR DESCRIPTION
在做项目的时候发现，在生成的View文件里，用events对象添加一些简单的事件处理，结果没有任何反应。后来发现在设置容器html时，应该传入$el对象，而不是$el对象的html字符串。修改后可以正常绑定事件。

**View**
`$('#body').html(this.$el.html());`

`$('#body').html(this.$el);`